### PR TITLE
Improve EPUB reader state handling and bookmarks

### DIFF
--- a/lib/ui/epub_reader_screen.dart
+++ b/lib/ui/epub_reader_screen.dart
@@ -1,13 +1,21 @@
+import 'dart:async';
+
 import 'package:epub_view/epub_view.dart';
 import 'package:universal_file/universal_file.dart' as uni;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/foundation.dart';
+import 'package:url_launcher/url_launcher.dart';
+
 import '../domain/book.dart';
 import '../data/book_repository.dart';
 import '../domain/bookmark.dart';
 import '../data/bookmark_repository.dart';
+import '../utils/epub_helpers.dart';
 
+/// Screen responsible for rendering an EPUB book and managing reader state.
 class EpubReaderScreen extends ConsumerStatefulWidget {
+  /// Book to open.
   final Book book;
   const EpubReaderScreen({super.key, required this.book});
 
@@ -15,50 +23,89 @@ class EpubReaderScreen extends ConsumerStatefulWidget {
   ConsumerState<EpubReaderScreen> createState() => _EpubReaderScreenState();
 }
 
-class _EpubReaderScreenState extends ConsumerState<EpubReaderScreen> {
+class _EpubReaderScreenState extends ConsumerState<EpubReaderScreen>
+    with WidgetsBindingObserver {
+  /// Controller from `epub_view` that handles rendering and navigation.
   late EpubController _controller;
+
+  /// Ensures we only jump to the stored CFI once.
   bool _didInitialCfiJump = false;
+
+  /// Listener reference so we can clean it up on dispose.
+  late VoidCallback _loadingListener;
+
+  /// Debouncer to avoid writing to the database on every tiny scroll.
+  Timer? _saveDebounce;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
+
+    // Initialize controller pointing to the book file.
     _controller = EpubController(
       document: EpubDocument.openFile(uni.File(widget.book.path)),
       epubCfi: widget.book.lastCfi,
     );
+    debugPrint('EpubReaderScreen init for book id: ${widget.book.id}');
 
-    // Ensure we jump to saved CFI when document finishes loading
-    _controller.loadingState.addListener(() {
+    // When the document finishes loading, jump to last known location if any.
+    _loadingListener = () {
+      debugPrint('Loading state: ${_controller.loadingState.value}');
       if (_controller.loadingState.value == EpubViewLoadingState.success &&
           !_didInitialCfiJump &&
           (widget.book.lastCfi != null && widget.book.lastCfi!.isNotEmpty)) {
         _didInitialCfiJump = true;
+        debugPrint('Jumping to stored CFI: ${widget.book.lastCfi}');
         _controller.gotoEpubCfi(widget.book.lastCfi!);
       }
-    });
+    };
+    _controller.loadingState.addListener(_loadingListener);
+
+    // Debounced saving of the current location.
+    _controller.currentValueListenable.addListener(_onLocationChanged);
+  }
+
+  /// Called whenever the reader's location changes.
+  /// Starts a debounce timer to persist the position shortly after.
+  void _onLocationChanged() {
+    debugPrint('Location changed');
+    _saveDebounce?.cancel();
+    _saveDebounce =
+        Timer(const Duration(milliseconds: 600), _saveLastLocation);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused) {
+      debugPrint('App paused; saving last location');
+      _saveLastLocation();
+    }
   }
 
   Future<void> _saveLastLocation() async {
-    if (widget.book.id != null) {
-      final cfi = _controller.generateEpubCfi();
-      if (cfi != null) {
-        await BookRepository().updateLastCfi(widget.book.id!, cfi);
-      }
-    }
+    if (widget.book.id == null) return;
+    final cfi = _controller.generateEpubCfi();
+    if (cfi == null || cfi.isEmpty) return;
+    debugPrint('Saving CFI: $cfi for book id: ${widget.book.id}');
+    await BookRepository().updateLastCfi(widget.book.id!, cfi);
   }
 
   Future<void> _addBookmark() async {
     if (widget.book.id == null) return;
     final cfi = _controller.generateEpubCfi();
     if (cfi == null) return;
-    final label = _currentChapterLabel();
+
+    final label = _currentChapterLabel() ?? 'Localização';
+    debugPrint('Adding bookmark: label="$label" cfi=$cfi');
     await BookmarkRepository().insert(Bookmark(
       bookId: widget.book.id!,
-      page: 1,
+      page: 0,
       cfi: cfi,
       label: label,
       createdAt: DateTime.now().millisecondsSinceEpoch,
     ));
+
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Marcador adicionado')),
@@ -68,6 +115,7 @@ class _EpubReaderScreenState extends ConsumerState<EpubReaderScreen> {
   Future<void> _showBookmarks() async {
     if (widget.book.id == null) return;
     final items = await BookmarkRepository().byBook(widget.book.id!);
+    debugPrint('Loaded ${items.length} bookmarks');
     if (!mounted) return;
     showModalBottomSheet(
       context: context,
@@ -83,6 +131,7 @@ class _EpubReaderScreenState extends ConsumerState<EpubReaderScreen> {
                       final cfi = bm.cfi;
                       Navigator.pop(context);
                       if (cfi != null) {
+                        debugPrint('Jumping to bookmark CFI: $cfi');
                         // jump after sheet closes
                         WidgetsBinding.instance.addPostFrameCallback((_) {
                           _controller.gotoEpubCfi(cfi);
@@ -98,6 +147,10 @@ class _EpubReaderScreenState extends ConsumerState<EpubReaderScreen> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _controller.currentValueListenable.removeListener(_onLocationChanged);
+    _saveDebounce?.cancel();
+    _controller.loadingState.removeListener(_loadingListener);
     _saveLastLocation();
     _controller.dispose();
     super.dispose();
@@ -106,7 +159,8 @@ class _EpubReaderScreenState extends ConsumerState<EpubReaderScreen> {
   @override
   Widget build(BuildContext context) {
     return PopScope(
-      onPopInvokedWithResult: (didPop, result) => _saveLastLocation(),
+      // Ensure we save the last position when leaving the screen.
+      onPopInvoked: (didPop) => _saveLastLocation(),
       child: Scaffold(
         appBar: AppBar(
           title: Text(widget.book.title),
@@ -116,8 +170,15 @@ class _EpubReaderScreenState extends ConsumerState<EpubReaderScreen> {
         ),
         body: Stack(
           children: [
+            // Actual EPUB rendering widget.
             EpubView(
               controller: _controller,
+              onExternalLinkPressed: (href) async {
+                final uri = Uri.tryParse(href);
+                if (uri != null && await canLaunchUrl(uri)) {
+                  await launchUrl(uri);
+                }
+              },
             ),
             Positioned(
               left: 16,
@@ -154,28 +215,45 @@ class _EpubReaderScreenState extends ConsumerState<EpubReaderScreen> {
 
   String? _currentChapterLabel() {
     final v = _controller.currentValueListenable.value;
-    final raw = (v?.chapter?.Title)?.trim();
+    final raw = v?.chapter?.Title?.trim();
     if (raw == null || raw.isEmpty) return null;
-    final cleaned = _cleanTitle(raw);
-    // Try to compute a chapter number from ToC
-    String prefix = '';
-    try {
-      final toc = _controller.tableOfContents();
-      final idx = toc.indexWhere((c) => (c.title ?? '').trim().toLowerCase() == raw.toLowerCase());
-      if (idx >= 0) prefix = 'Capítulo ${idx + 1} — ';
-    } catch (_) {}
-    final text = cleaned.isEmpty ? (prefix.isNotEmpty ? prefix.replaceAll(RegExp(r'\s—\s?$'), '') : null) : '$prefix$cleaned';
+
+    final cleaned = cleanTitle(raw);
+    final toc = _flattenTocSafe();
+    final idx = toc.indexWhere((t) => normTitle(t) == normTitle(raw));
+    debugPrint('Current chapter: raw="$raw" cleaned="$cleaned" index=$idx');
+
+    final prefix = idx >= 0 ? 'Capítulo ${idx + 1} — ' : '';
+    final text = cleaned.isEmpty
+        ? (prefix.isNotEmpty ? prefix.substring(0, prefix.length - 3) : null)
+        : '$prefix$cleaned';
     return text?.trim();
   }
 
-  String _cleanTitle(String s) {
-    final lowered = s.toLowerCase();
-    // Filter common Gutenberg headings
-    if (lowered.contains('project gutenberg')) {
-      // Return empty so we can fall back to prefix only
-      return '';
+  /// Returns a flattened list of chapter titles from the EPUB TOC.
+  List<String> _flattenTocSafe() {
+    try {
+      final toc = _controller.tableOfContents();
+      final out = <String>[];
+      void walk(dynamic node) {
+        if (node == null) return;
+        final title = (node.title ?? '').toString();
+        if (title.trim().isNotEmpty) out.add(title);
+        final children = node.subChapters as List<dynamic>?;
+        if (children != null) {
+          for (final c in children) {
+            walk(c);
+          }
+        }
+      }
+
+      for (final n in toc) {
+        walk(n);
+      }
+      return out;
+    } catch (_) {
+      return const [];
     }
-    // Remove excessive whitespace
-    return s.replaceAll(RegExp(r'\s+'), ' ').trim();
   }
+
 }

--- a/lib/utils/epub_helpers.dart
+++ b/lib/utils/epub_helpers.dart
@@ -1,0 +1,21 @@
+/// Normalizes a string by collapsing whitespace and lowercasing.
+String normTitle(String s) => s.replaceAll(RegExp(r'\s+'), ' ').trim().toLowerCase();
+
+/// Cleans common noisy prefixes from chapter titles found in public EPUBs.
+///
+/// Examples removed: "Chapter 1 -", "Capítulo 2:", "Project Gutenberg" headers.
+String cleanTitle(String s) {
+  var r = s.replaceAll(RegExp(r'\s+'), ' ').trim();
+  final lowered = r.toLowerCase();
+  if (lowered.contains('project gutenberg') ||
+      lowered.startsWith('chapter ') ||
+      lowered.startsWith('capítulo ')) {
+    r = r.replaceFirst(
+      RegExp(r'^(chapter|capítulo)\s+\d+\s*[:\-–—]\s*', caseSensitive: false),
+      '',
+    );
+    if (r.toLowerCase().contains('project gutenberg')) return '';
+  }
+  return r.trim();
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   path: any
   epub_view: any
   universal_file: any
+  url_launcher: any
 
 dev_dependencies:
   flutter_test:

--- a/test/epub_helpers_test.dart
+++ b/test/epub_helpers_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stellareader/utils/epub_helpers.dart';
+
+void main() {
+  group('epub helpers', () {
+    test('cleanTitle removes noise', () {
+      expect(cleanTitle('Chapter 1 - Introduction'), 'Introduction');
+      expect(cleanTitle('Capítulo 2: O Início'), 'O Início');
+      expect(cleanTitle('Project Gutenberg'), '');
+    });
+
+    test('normTitle collapses whitespace and lowercases', () {
+      expect(normTitle('  Hello   World '), 'hello world');
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- save reader position with debounced updates and lifecycle awareness
- clean up listeners and handle external links gracefully
- enrich bookmarks and chapter labels
- add debug logs, comments, and unit tests for title helpers

## Testing
- `dart format lib/ui/epub_reader_screen.dart lib/utils/epub_helpers.dart test/epub_helpers_test.dart pubspec.yaml` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e37cebe8832baa940501cde5419f