### PR TITLE
feat: improve chapter parsing

### DIFF
--- a/lib/ui/epub_reader_screen.dart
+++ b/lib/ui/epub_reader_screen.dart
@@ -228,7 +228,7 @@ class _EpubReaderScreenState extends ConsumerState<EpubReaderScreen>
 
     final cleaned = cleanTitle(raw);
     final toc = _flattenTocSafe();
-    final idx = toc.indexWhere((t) => normTitle(t) == normTitle(raw));
+    final idx = chapterIndex(raw, toc);
     debugPrint('Current chapter: raw="$raw" cleaned="$cleaned" index=$idx');
     final prefix = idx >= 0 ? 'Capítulo ${idx + 1} — ' : '';
     final text = cleaned.isEmpty

--- a/lib/utils/epub_helpers.dart
+++ b/lib/utils/epub_helpers.dart
@@ -19,3 +19,23 @@ String cleanTitle(String s) {
   return r.trim();
 }
 
+/// Finds the index of [rawTitle] inside the given [toc] (table of contents).
+///
+/// Titles are normalised and cleaned before comparison, so variants like
+/// "Chapter 1 - Foo" and "Capítulo 1: Foo" all resolve to the same entry.
+/// Returns `-1` when no matching chapter is found or when the cleaned title
+/// is empty (e.g. Project Gutenberg licence pages).
+int chapterIndex(String rawTitle, List<String> toc) {
+  final cleanedRaw = cleanTitle(rawTitle);
+  if (cleanedRaw.isEmpty) return -1;
+  final target = normTitle(cleanedRaw);
+
+  for (var i = 0; i < toc.length; i++) {
+    final ct = cleanTitle(toc[i]);
+    if (ct.isEmpty) continue;
+    if (normTitle(ct) == target) return i;
+  }
+
+  return -1;
+}
+

--- a/test/epub_helpers_test.dart
+++ b/test/epub_helpers_test.dart
@@ -12,6 +12,13 @@ void main() {
     test('normTitle collapses whitespace and lowercases', () {
       expect(normTitle('  Hello   World '), 'hello world');
     });
+
+    test('chapterIndex resolves chapter positions', () {
+      final toc = ['Preface', 'Chapter 1: Start', 'Capítulo 2 - Meio'];
+      expect(chapterIndex('Chapter 1 - Start', toc), 1);
+      expect(chapterIndex('Capítulo 2: Meio', toc), 2);
+      expect(chapterIndex('Project Gutenberg', toc), -1);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- normalize and clean titles to match chapters against the TOC
- use the chapter index helper when resolving the current chapter label
- cover chapterIndex with unit tests

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f7154cc8832bb7bc9e044b5198cf